### PR TITLE
Fix up some remapping issues

### DIFF
--- a/tool/dta-tool/app/Main.hs
+++ b/tool/dta-tool/app/Main.hs
@@ -28,7 +28,9 @@ main = do
         parseResult2 <- parseCFile (newGCC "gcc") Nothing [] fp2
         let parsed1 = resultOrDie parseResult1
             parsed2 = resultOrDie parseResult2
-            instrumentedAst1 = instrumentation parsed1
-            instrumentedAst2 = instrumentation parsed2
+            (instrumentedAst1, taintEnv1) = instrumentation parsed1
+            (instrumentedAst2, _) = instrumentation parsed2
         pp <- productProgram "main1" instrumentedAst1 instrumentedAst2
         print $ pretty pp
+        -- print parseResult1
+        print $ taintEnv1

--- a/tool/dta-tool/src/InstrumentationState.hs
+++ b/tool/dta-tool/src/InstrumentationState.hs
@@ -1,6 +1,7 @@
 module InstrumentationState(
 InstrumentationState, 
     taints,
+    taintEnv,
     preservingFns,
     nonPreservingFns,
 addToLog, addPrettyToLog,
@@ -9,6 +10,7 @@ emptyInstState
 where
 import EntropicDependency
 import TaintMap
+import TaintEnv
 
 import Language.C.Data.Position
 import Language.C.Data.Node
@@ -24,13 +26,15 @@ data InstrumentationState = IState
     { 
         notes :: String, 
         taints :: TaintMap,
+        taintEnv :: TaintEnv,
         preservingFns :: [Decl],
         nonPreservingFns :: [Decl]
     }
 
 instance Show InstrumentationState where
     show is = "Log: " ++ notes is ++ "\n\n" ++
-                "Taint values: " ++ show (Map.mapKeys (show . pretty) (globalTaints (taints is))) 
+                "Taint values: " ++ show (Map.mapKeys (show . pretty) (globalTaints (taints is))) ++
+                "Taint tree: " ++ show (taintEnv is)
 
 addPrettyToLog :: (Pretty a) => a -> InstrumentationState -> InstrumentationState
 addPrettyToLog o is = let lg = notes is ++ show (pretty o)  ++ "\n" in is { notes = lg }
@@ -42,6 +46,7 @@ emptyInstState :: InstrumentationState
 emptyInstState = IState { 
                     notes = "", 
                     taints = emptyTaintMap,
+                    taintEnv = emptyTaintEnv,
                     preservingFns = [],
                     nonPreservingFns = []
                     }

--- a/tool/dta-tool/src/InstrumentationTrav.hs
+++ b/tool/dta-tool/src/InstrumentationTrav.hs
@@ -5,7 +5,8 @@ InstTrav,
 addPreservingFn, addNonPreservingFn,
 getPreservingFns, getNonPreservingFns,
 addToTaints, updateTaint, getTaintValue, getTaintMap, setTaintMap, withTaintMap,
-enterBlockScope, leaveBlockScope, enterFunctionScope, leaveFunctionScope
+getTaintEnv, updateTaintEnv,
+enterBlockScope, leaveBlockScope, enterFunctionScope, leaveFunctionScope,
 )
 where
 import Prelude hiding (log)
@@ -13,6 +14,7 @@ import Prelude hiding (log)
 import EntropicDependency
 import InstrumentationState
 import TaintMap
+import TaintEnv
 import Loggable
 
 import Language.C.Syntax.AST
@@ -66,6 +68,12 @@ setTaintMap tm = modifyUserState (\st -> st { taints = tm })
 
 withTaintMap :: (TaintMap -> TaintMap) -> InstTrav ()
 withTaintMap f = getTaintMap >>= setTaintMap . f
+
+getTaintEnv :: InstTrav TaintEnv 
+getTaintEnv = taintEnv <$> getUserState
+
+updateTaintEnv :: String -> TaintTree -> InstTrav ()
+updateTaintEnv fnName tTree = modifyUserState (\st -> st { taintEnv = Map.insert fnName tTree (taintEnv st) })
 
 -- scope manipulation
 

--- a/tool/dta-tool/src/ProductProgram.hs
+++ b/tool/dta-tool/src/ProductProgram.hs
@@ -57,11 +57,25 @@ prodProg fnName p1 p2
             retType = getReturnType p1
             varName = VarName (mkIdent nopos fnName (Name 0)) Nothing
             declAttrs = declAttrs1
-            fType = FunType retType (params1 ++ params2) (isVar1 || isVar2)
+            fType = FunType retType params1 (isVar1 || isVar2)
             funType = FunctionType fType noAttributes -- TODO: place in attributes from p1 or p2
             varDecl = VarDecl varName declAttrs funType
-            body = head $ prodStmts body1 body2
+            (CCompound localLabels bodyItems node) = head $ prodStmts body1 body2
+            paramDecls = CBlockDecl <$> makeParamDecls params1 params2
+            body = CCompound localLabels (paramDecls ++ bodyItems) node
         in FunDef varDecl body node1
+
+makeParamDecls :: [ParamDecl] -> [ParamDecl] -> [CDecl]
+makeParamDecls = zipWith f
+    where 
+        f pd1 pd2@(ParamDecl (VarDecl vName (DeclAttrs _ _ attrs) ty) node) = 
+            let id1 = declIdent pd1
+                id2 = declIdent pd2
+                (declspecs, declr) = exportDeclr [] ty attrs vName
+                initExpr = CVar id1 undefNode
+                init = CInitExpr initExpr undefNode
+            in CDecl declspecs [(Just declr, Just init, Nothing)] undefNode
+        f _ _ = error "Abstract parameters in producted function"
 
 prodBlocks :: [CBlockItem] -> [CBlockItem] -> [CBlockItem]
 prodBlocks bs1 [] = bs1

--- a/tool/dta-tool/src/ProductProgram.hs
+++ b/tool/dta-tool/src/ProductProgram.hs
@@ -57,7 +57,7 @@ prodProg fnName p1 p2
             retType = getReturnType p1
             varName = VarName (mkIdent nopos (fnName ++ versionSuffix SecondVersion) (Name 0)) Nothing
             declAttrs = declAttrs1
-            fType = FunType retType params1 (isVar1 || isVar2)
+            fType = FunType retType params2 (isVar1 || isVar2)
             funType = FunctionType fType noAttributes -- TODO: place in attributes from p1 or p2
             varDecl = VarDecl varName declAttrs funType
             (CCompound localLabels bodyItems node) = head $ prodStmts body1 body2
@@ -70,11 +70,11 @@ prodProg fnName p1 p2
 makeParamDecls :: [ParamDecl] -> [ParamDecl] -> [CDecl]
 makeParamDecls = zipWith f
     where 
-        f pd1 pd2@(ParamDecl (VarDecl vName (DeclAttrs _ _ attrs) ty) node) = 
+        f pd1@(ParamDecl (VarDecl vName (DeclAttrs _ _ attrs) ty) node) pd2 = 
             let id1 = declIdent pd1
                 id2 = declIdent pd2
                 (declspecs, declr) = exportDeclr [] ty attrs vName
-                initExpr = CVar id1 undefNode
+                initExpr = CVar id2 undefNode
                 init = CInitExpr initExpr undefNode
             in CDecl declspecs [(Just declr, Just init, Nothing)] undefNode
         f _ _ = error "Abstract parameters in producted function"

--- a/tool/dta-tool/src/ProductProgram.hs
+++ b/tool/dta-tool/src/ProductProgram.hs
@@ -55,7 +55,7 @@ prodProg fnName p1 p2
             (params1, isVar1) = getFnParams p1
             (params2, isVar2) = getFnParams p2
             retType = getReturnType p1
-            varName = VarName (mkIdent nopos fnName (Name 0)) Nothing
+            varName = VarName (mkIdent nopos (fnName ++ versionSuffix SecondVersion) (Name 0)) Nothing
             declAttrs = declAttrs1
             fType = FunType retType params1 (isVar1 || isVar2)
             funType = FunctionType fType noAttributes -- TODO: place in attributes from p1 or p2
@@ -65,6 +65,8 @@ prodProg fnName p1 p2
             body = CCompound localLabels (paramDecls ++ bodyItems) node
         in FunDef varDecl body node1
 
+-- this function initializes the parameters of the second version of the
+-- productized program to be the parameters of the first version
 makeParamDecls :: [ParamDecl] -> [ParamDecl] -> [CDecl]
 makeParamDecls = zipWith f
     where 

--- a/tool/dta-tool/src/TaintEnv.hs
+++ b/tool/dta-tool/src/TaintEnv.hs
@@ -1,0 +1,29 @@
+module TaintEnv(
+TaintEnv,
+TaintVal,
+TaintTree(..),
+emptyTaintEnv, getTaintVal
+)
+where
+
+import Language.C.Syntax.AST
+import qualified Data.Map as Map
+
+type TaintVal = Bool
+
+type TaintEnv = Map.Map String TaintTree 
+
+emptyTaintEnv = Map.empty
+
+data TaintTree = 
+    CompoundTaint TaintVal [TaintTree] |
+    IfTaint TaintVal TaintTree (Maybe TaintTree) |
+    AtomTaint TaintVal |
+    EmptyTaintTree
+    deriving (Show)
+
+getTaintVal :: TaintTree -> TaintVal
+getTaintVal (CompoundTaint tv _) = tv
+getTaintVal (IfTaint tv _ _) = tv
+getTaintVal (AtomTaint tv) = tv
+getTaintVal EmptyTaintTree = False

--- a/tool/dta-tool/src/TaintEnv.hs
+++ b/tool/dta-tool/src/TaintEnv.hs
@@ -2,12 +2,15 @@ module TaintEnv(
 TaintEnv,
 TaintVal,
 TaintTree(..),
-emptyTaintEnv, getTaintVal
+emptyTaintEnv, getTaintVal,
+entropicDepToTaintVal
 )
 where
 
 import Language.C.Syntax.AST
 import qualified Data.Map as Map
+
+import EntropicDependency
 
 type TaintVal = Bool
 
@@ -18,12 +21,16 @@ emptyTaintEnv = Map.empty
 data TaintTree = 
     CompoundTaint TaintVal [TaintTree] |
     IfTaint TaintVal TaintTree (Maybe TaintTree) |
-    AtomTaint TaintVal |
-    EmptyTaintTree
+    AtomTaint TaintVal
     deriving (Show)
+
+entropicDepToTaintVal :: EntropicDependency -> TaintVal
+entropicDepToTaintVal Source = True
+entropicDepToTaintVal HighEntropy = True
+entropicDepToTaintVal LowEntropy = False
+entropicDepToTaintVal NoDependency = False
 
 getTaintVal :: TaintTree -> TaintVal
 getTaintVal (CompoundTaint tv _) = tv
 getTaintVal (IfTaint tv _ _) = tv
 getTaintVal (AtomTaint tv) = tv
-getTaintVal EmptyTaintTree = False

--- a/tool/dta-tool/src/Utils.hs
+++ b/tool/dta-tool/src/Utils.hs
@@ -4,7 +4,8 @@ identOfDecl, identOfExpr,
 resultOrDie, runTravOrDie, runTravOrDie_,
 getFunDef, emptyFunDef, appendToId,
 getReturnType, getFnParams,
-filterBuiltIns, isMain
+filterBuiltIns, isMain,
+strToIdent
 )
 where
 import Language.C.Syntax.AST
@@ -107,3 +108,4 @@ isMain (CDeclr maybeId _ _ _ _) = maybe False isMainId maybeId
     where
         isMainId ident = identToString ident == "main"
 
+strToIdent s = mkIdent nopos s (Name 0)

--- a/tool/dta-tool/src/Utils.hs
+++ b/tool/dta-tool/src/Utils.hs
@@ -5,7 +5,7 @@ resultOrDie, runTravOrDie, runTravOrDie_,
 getFunDef, emptyFunDef, appendToId,
 getReturnType, getFnParams,
 filterBuiltIns, isMain,
-strToIdent
+strToIdent,
 )
 where
 import Language.C.Syntax.AST
@@ -21,6 +21,7 @@ import Language.C.Analysis.SemRep
 import qualified Data.List as List
 import qualified Data.Map as Map
 import Data.Maybe
+
 
 makeStrConst :: String -> CExpr -> CExpr
 makeStrConst strConst expr = let node_info = nodeInfo expr 
@@ -109,3 +110,5 @@ isMain (CDeclr maybeId _ _ _ _) = maybe False isMainId maybeId
         isMainId ident = identToString ident == "main"
 
 strToIdent s = mkIdent nopos s (Name 0)
+
+

--- a/tool/dta-tool/src/VarRemap.hs
+++ b/tool/dta-tool/src/VarRemap.hs
@@ -83,7 +83,11 @@ remapIdent version id =
 
 remapFun :: ProgramVersion -> CFunDef -> CFunDef
 remapFun version (CFunDef declspecs declr oldstyle_decls stmt node_info) =
-    let declr' = if isMain declr then declr else remapDeclr version declr
+    let declr' = let
+                    newDeclr@(CDeclr maybeId derivedDeclrs maybeStrLit attrs node) = remapDeclr version declr
+                 in if isMain declr 
+                    then (CDeclr (Just (strToIdent "main")) derivedDeclrs maybeStrLit attrs node)
+                    else newDeclr
         stmt' = remapStmt version stmt
     in CFunDef declspecs declr' oldstyle_decls stmt' node_info
 

--- a/tool/dta-tool/test3.c
+++ b/tool/dta-tool/test3.c
@@ -1,4 +1,8 @@
 int main(int argc, char** argv) {
+    return main1(argc, argv);
+}
+
+int main1(int test, char** test_c) {
     char** foo;
     char* bar;
     int k = 0;

--- a/tool/dta-tool/test3v2.c
+++ b/tool/dta-tool/test3v2.c
@@ -1,4 +1,8 @@
 int main(int argc, char** argv) {
+    return main1(argc, argv);
+}
+
+int main1(int test, char** test_c) {
     char** foo;
     char* bar;
     int k = 0;

--- a/tool/dta-tool/test5.c
+++ b/tool/dta-tool/test5.c
@@ -1,10 +1,12 @@
 int main(int argc, char** argv) {
+    int asdf;
     for (int i = 0; i < 4; i++) {
         return;
     }
 }
 
 int main1(int argc, char** argv) {
+    int foo;
     for (int i = 0; i < 4; i++) {
         return;
     }


### PR DESCRIPTION
1. Product function now uses second version name (e.g. functionName_2)
2. Product function uses second version args, and initializes first version args to be the second version. So if the original function def is `functionName(int arg1, char arg2)` then the product becomes:

    functionName_2(int arg1_2, char arg2_2) {
        int arg1_1 = arg1_2;
        char arg2_1 = arg2_2;
        ....
    }